### PR TITLE
Update forge

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ minecraft.runs.all {
 }
 
 dependencies {
-    minecraft 'net.minecraftforge:forge:1.18-38.0.8'
+    minecraft 'net.minecraftforge:forge:1.18-38.0.12'
 
 	library group: "org.jetbrains.kotlin", name: "kotlin-stdlib-jdk8", version: kotlin_version
 	library group: "org.jetbrains.kotlin", name: "kotlin-reflect", version: kotlin_version


### PR DESCRIPTION
This is a very temporary solution to a very big problem: If you add KFF to a project, it restricts you to using the exact Forge version as KFF (currently: `38.0.12`). Unless KFF has some kind of bot set up to update itself, or gets regular updates, this is unsustainable.