### PR TITLE
Add some syntax sugars and utils

### DIFF
--- a/kfflib/build.gradle.kts
+++ b/kfflib/build.gradle.kts
@@ -70,6 +70,10 @@ configurations {
     runtimeElements {
         setExtendsFrom(emptySet())
     }
+    api {
+        minecraftLibrary.get().extendsFrom(this)
+        minecraftLibrary.get().exclude("org.jetbrains", "annotations")
+    }
 }
 
 dependencies {

--- a/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/forge/CapabilityUtil.kt
+++ b/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/forge/CapabilityUtil.kt
@@ -1,0 +1,8 @@
+package thedarkcolour.kotlinforforge.forge
+
+import net.minecraft.core.Direction
+import net.minecraftforge.common.capabilities.Capability
+import net.minecraftforge.common.capabilities.ICapabilityProvider
+
+public fun <T> ICapabilityProvider.getCapabilityOrThrow(cap: Capability<T>, direction: Direction? = null): T =
+    getCapability(cap, direction).resolve().orElseThrow()

--- a/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/forge/PoseStackUtil.kt
+++ b/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/forge/PoseStackUtil.kt
@@ -1,0 +1,12 @@
+package thedarkcolour.kotlinforforge.forge
+
+import com.mojang.blaze3d.vertex.PoseStack
+import com.mojang.math.Quaternion
+
+public fun PoseStack.use(toRun: () -> Unit) {
+    pushPose()
+    toRun()
+    popPose()
+}
+
+public operator fun PoseStack.timesAssign(matrix: Quaternion): Unit = mulPose(matrix)

--- a/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/forge/ProfilerUtil.kt
+++ b/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/forge/ProfilerUtil.kt
@@ -1,0 +1,15 @@
+package thedarkcolour.kotlinforforge.forge
+
+import net.minecraft.util.profiling.ProfilerFiller
+
+public fun ProfilerFiller.use(name: String, toProfile: () -> Unit) {
+    push(name)
+    toProfile()
+    pop()
+}
+
+public fun ProfilerFiller.use(supplier: () -> String, toProfile: () -> Unit) {
+    push(supplier)
+    toProfile()
+    pop()
+}

--- a/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/forge/vectorutil/Vec2Util.kt
+++ b/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/forge/vectorutil/Vec2Util.kt
@@ -1,0 +1,15 @@
+package thedarkcolour.kotlinforforge.forge.vectorutil
+
+import net.minecraft.world.phys.Vec2
+
+public operator fun Vec2.plus(other: Vec2): Vec2 = add(other)
+
+public operator fun Vec2.minus(other: Vec2): Vec2 = add(-other)
+
+public operator fun Vec2.unaryMinus(): Vec2 = negated()
+
+public operator fun Vec2.times(times: Float): Vec2 = scale(times)
+
+public fun Vec2.clone(): Vec2 {
+    return Vec2(x, y)
+}

--- a/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/forge/vectorutil/Vec3Util.kt
+++ b/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/forge/vectorutil/Vec3Util.kt
@@ -1,0 +1,16 @@
+package thedarkcolour.kotlinforforge.forge.vectorutil
+
+import net.minecraft.world.phys.Vec3
+
+
+public operator fun Vec3.plus(other: Vec3): Vec3 = add(other)
+
+public operator fun Vec3.unaryMinus(): Vec3 = this * -1.0
+
+public operator fun Vec3.minus(other: Vec3): Vec3 = subtract(other)
+
+public operator fun Vec3.times(times: Double): Vec3 = scale(times)
+
+public fun Vec3.clone(): Vec3 {
+    return Vec3(x, y, z)
+}

--- a/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/forge/vectorutil/Vec3iUtil.kt
+++ b/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/forge/vectorutil/Vec3iUtil.kt
@@ -1,0 +1,19 @@
+package thedarkcolour.kotlinforforge.forge.vectorutil
+
+import net.minecraft.core.Vec3i
+
+public operator fun Vec3i.plus(other: Vec3i): Vec3i = offset(other)
+
+public operator fun Vec3i.unaryMinus(): Vec3i = this * -1
+
+public operator fun Vec3i.minus(other: Vec3i): Vec3i = subtract(other)
+
+public operator fun Vec3i.times(times: Int): Vec3i = multiply(times)
+
+public infix fun Vec3i.dot(other: Vec3i): Int {
+    return x * other.x + y * other.y + z * other.z
+}
+
+public fun Vec3i.clone(): Vec3i {
+    return Vec3i(x, y, z)
+}

--- a/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/forge/vectorutil/Vector3dUtil.kt
+++ b/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/forge/vectorutil/Vector3dUtil.kt
@@ -1,0 +1,39 @@
+package thedarkcolour.kotlinforforge.forge.vectorutil
+
+import com.mojang.math.Vector3d
+
+public operator fun Vector3d.plusAssign(other: Vector3d): Unit = add(other)
+
+public operator fun Vector3d.plus(other: Vector3d): Vector3d {
+    return Vector3d(x + other.x, y + other.y, z + other.z)
+}
+
+public operator fun Vector3d.unaryMinus(): Vector3d = this * -1.0
+
+public operator fun Vector3d.minusAssign(other: Vector3d) {
+    x -= other.x
+    y -= other.y
+    z -= other.z
+}
+
+public operator fun Vector3d.minus(other: Vector3d): Vector3d {
+    return Vector3d(x - other.x, y - other.y, z - other.z)
+}
+
+public operator fun Vector3d.timesAssign(times: Double): Unit = scale(times)
+
+public operator fun Vector3d.times(times: Double): Vector3d {
+    return Vector3d(x * times, y * times, z * times)
+}
+
+public infix fun Vector3d.dot(other: Vector3d): Double {
+    return x * other.x + y * other.y + z * other.z
+}
+
+public infix fun Vector3d.cross(other: Vector3d): Vector3d {
+    return Vector3d((y * other.z - z * other.y), (z * other.x - x * other.z), (x * other.y - y * other.x))
+}
+
+public fun Vector3d.clone(): Vector3d {
+    return Vector3d(x, y, z)
+}

--- a/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/forge/vectorutil/Vector3fUtil.kt
+++ b/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/forge/vectorutil/Vector3fUtil.kt
@@ -1,0 +1,33 @@
+package thedarkcolour.kotlinforforge.forge.vectorutil
+
+import com.mojang.math.Vector3f
+
+public operator fun Vector3f.plusAssign(other: Vector3f): Unit = add(other)
+
+public operator fun Vector3f.plus(other: Vector3f): Vector3f {
+    val newOne = Vector3f(x(), y(), z())
+    newOne += other
+    return newOne
+}
+
+public operator fun Vector3f.unaryMinus(): Vector3f = this * -1F
+
+public operator fun Vector3f.minusAssign(other: Vector3f): Unit = sub(other)
+
+public operator fun Vector3f.minus(other: Vector3f): Vector3f {
+    val newOne = Vector3f(x(), y(), z())
+    newOne -= other
+    return newOne
+}
+
+public operator fun Vector3f.timesAssign(times: Float): Unit = mul(times)
+
+public operator fun Vector3f.times(times: Float): Vector3f {
+    val newOne = Vector3f(x(), y(), z())
+    newOne *= times
+    return newOne
+}
+
+public fun Vector3f.clone(): Vector3f {
+    return Vector3f(x(), y(), z())
+}

--- a/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/forge/vectorutil/Vector4fUtil.kt
+++ b/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/forge/vectorutil/Vector4fUtil.kt
@@ -1,0 +1,36 @@
+package thedarkcolour.kotlinforforge.forge.vectorutil
+
+import com.mojang.math.Vector3f
+import com.mojang.math.Vector4f
+
+public operator fun Vector4f.plusAssign(other: Vector4f): Unit = add(other.x(), other.y(), other.z(), other.w())
+
+public operator fun Vector4f.plus(other: Vector4f): Vector4f {
+    val newOne = Vector4f(x(), y(), z(), w())
+    newOne += other
+    return newOne
+}
+
+public operator fun Vector4f.unaryMinus(): Vector4f = this * -1F
+
+public operator fun Vector4f.minusAssign(other: Vector4f): Unit = add(-other.x(), -other.y(), -other.z(), -other.w())
+
+public operator fun Vector4f.minus(other: Vector4f): Vector4f {
+    val newOne = Vector4f(x(), y(), z(), w())
+    newOne -= other
+    return newOne
+}
+
+public operator fun Vector4f.timesAssign(times: Float): Unit = mul(times)
+
+public operator fun Vector4f.timesAssign(other: Vector3f): Unit = mul(other)
+
+public operator fun Vector4f.times(times: Float): Vector4f {
+    val newOne = Vector4f(x(), y(), z(), w())
+    newOne *= times
+    return newOne
+}
+
+public fun Vector4f.clone(): Vector4f {
+    return Vector4f(x(), y(), z(), w())
+}

--- a/kfflib/src/test/kotlin/thedarkcolour/kfflibtest/KFFLibTest.kt
+++ b/kfflib/src/test/kotlin/thedarkcolour/kfflibtest/KFFLibTest.kt
@@ -19,14 +19,21 @@ import thedarkcolour.kotlinforforge.forge.MOD_CONTEXT
  * check out the [KotlinModdingSkeleton repository](https://github.com/thedarkcolour/KotlinModdingSkeleton).
  */
 @Mod(KFFLibTest.ID)
-object KFFLibTest {
-    const val ID = "kfflibtest"
+public object KFFLibTest {
+    internal const val ID = "kfflibtest"
 
-    val LOGGER: Logger = LogManager.getLogger(ID)
+    internal val LOGGER: Logger = LogManager.getLogger(ID)
 
     init {
         LOGGER.log(Level.INFO, "Hello world!")
 
         ModBlocks.REGISTRY.register(MOD_BUS)
+
+        testVec2()
+        testVec3i()
+        testVec3()
+        testVector3d()
+        testVector3f()
+        testVector4f()
     }
 }

--- a/kfflib/src/test/kotlin/thedarkcolour/kfflibtest/VectorTester.kt
+++ b/kfflib/src/test/kotlin/thedarkcolour/kfflibtest/VectorTester.kt
@@ -1,0 +1,144 @@
+package thedarkcolour.kfflibtest
+
+import com.mojang.math.Vector3d
+import com.mojang.math.Vector3f
+import com.mojang.math.Vector4f
+import net.minecraft.core.Vec3i
+import net.minecraft.world.phys.Vec2
+import net.minecraft.world.phys.Vec3
+import thedarkcolour.kotlinforforge.forge.vectorutil.*
+
+internal fun testVec2() {
+    val v1 = Vec2(1.0F, 1.0F)
+    val v2 = Vec2(2.0F, 2.0F)
+
+    assert(v1 + v2 == Vec2(3.0F, 3.0F)) { "Vec2 addition has failed!" }
+    assert(v1 - v2 == Vec2(-1.0F, -1.0F)) { "Vec2 subtraction has failed!" }
+    assert(-v1 == Vec2(-1.0F, -1.0F)) { "Vec2 unaryMinus has failed!" }
+    assert(v1 * 2.2F == Vec2(2.2F, 2.2F)) { "Vec2 multiplication has failed! " }
+    assert(v1.clone() == v1) { "Vec2 cloning has failed! " }
+
+    assert(v1 == Vec2(1.0F, 1.0F)) { "v1 has been mutated!" }
+    assert(v2 == Vec2(2.0F, 2.0F)) { "v1 has been mutated!" }
+
+    KFFLibTest.LOGGER.info("Vec2 test succeed")
+}
+
+internal fun testVec3i() {
+    val v1 = Vec3i(1, 1, 1)
+    val v2 = Vec3i(2, 2, 2)
+
+    assert(v1 + v2 == Vec3i(3, 3, 3)) { "Vec3i addition has failed!" }
+    assert(v1 - v2 == Vec3i(-1, -1, -1)) { "Vec3i subtraction has failed!" }
+    assert(-v1 == Vec3i(-1, -1, -1)) { "Vec3i unaryMinus has failed!" }
+    assert(v1 * 23 == Vec3i(23, 23, 23)) { "Vec3i multiplication has failed! " }
+    assert(v1 dot v2 == 6) { "Vec3i dot product has failed! " }
+    assert(v1.clone() == v1) { "Vec3i cloning has failed! " }
+
+    assert(v1 == Vec3i(1, 1, 1)) { "v1 has been mutated!" }
+    assert(v2 == Vec3i(2, 2, 2)) { "v1 has been mutated!" }
+
+    KFFLibTest.LOGGER.info("Vec3i test succeed")
+}
+
+internal fun testVec3() {
+    val v1 = Vec3(1.0, 1.0, 1.0)
+    val v2 = Vec3(2.0, 2.0, 2.0)
+
+    assert(v1 + v2 == Vec3(3.0, 3.0, 3.0)) { "Vec3 addition has failed!" }
+    assert(v1 - v2 == Vec3(-1.0, -1.0, -1.0)) { "Vec3 subtraction has failed!" }
+    assert(-v1 == Vec3(-1.0, -1.0, -1.0)) { "Vec3 unaryMinus has failed!" }
+    assert(v1 * 23.0 == Vec3(23.0, 23.0, 23.0)) { "Vec3 multiplication has failed! " }
+    assert(v1.clone() == v1) { "Vec3 cloning has failed! " }
+
+    assert(v1 == Vec3(1.0, 1.0, 1.0)) { "v1 has been mutated!" }
+    assert(v2 == Vec3(2.0, 2.0, 2.0)) { "v1 has been mutated!" }
+
+    KFFLibTest.LOGGER.info("Vec3 test succeed")
+}
+
+internal fun testVector3d() {
+    val v1 = Vector3d(0.0, 13.0, 21.0)
+    val v2 = Vector3d(-17.0, -42.0, 23.0)
+
+    assert(v1 + v2 == Vector3d(-17.0, -29.0, 44.0)) { "Vector3d addition has failed!" }
+    assert(v1 - v2 == Vector3d(17.0, 55.0, -2.0)) { "Vector3d subtraction has failed!" }
+    assert(-v1 == Vector3d(0.0, -13.0, -21.0)) { "Vector3d unaryMinus has failed!" }
+    assert(v1 * 23.0 == Vector3d(0.0, 299.0, 483.0)) { "Vector3d multiplication has failed! " }
+    assert(v1 dot v2 == -63.0) { "Vector3d dot product has failed! " }
+    assert(v1 cross v2 == Vector3d(1181.0, -357.0, 221.0)) { "Vector3d multiplication has failed! " }
+    assert(v1.clone() == v1) { "Vector3d cloning has failed! " }
+
+    assert(v1 == Vector3d(0.0, 13.0, 21.0)) { "v1 has been mutated!" }
+    assert(v2 == Vector3d(-17.0, -42.0, 23.0)) { "v1 has been mutated!" }
+
+    val plusAssign = v1.clone()
+    plusAssign += v2
+    assert(v1 + v2 == plusAssign) { "Vector3d addition&assign has failed!" }
+
+    val minusAssign = v1.clone()
+    minusAssign -= v2
+    assert(v1 - v2 == minusAssign) { "Vector3d subtraction&assign has failed!" }
+
+    val timesAssign = v1.clone()
+    timesAssign *= 23.0
+    assert(v1 * 23.0 == timesAssign) { "Vector3d multiplication&assign has failed!" }
+
+    KFFLibTest.LOGGER.info("Vector3d test succeed")
+}
+
+internal fun testVector3f() {
+    val v1 = Vector3f(0.0F, 13.0F, 21.0F)
+    val v2 = Vector3f(-17.0F, -42.0F, 23.0F)
+
+    assert(v1 + v2 == Vector3f(-17.0F, -29.0F, 44.0F)) { "Vector3f addition has failed!" }
+    assert(v1 - v2 == Vector3f(17.0F, 55.0F, -2.0F)) { "Vector3f subtraction has failed!" }
+    assert(-v1 == Vector3f(0.0F, -13.0F, -21.0F)) { "Vector3f unaryMinus has failed!" }
+    assert(v1 * 23.0F == Vector3f(0.0F, 299.0F, 483.0F)) { "Vector3f multiplication has failed! " }
+    assert(v1.clone() == v1) { "Vector3f cloning has failed! " }
+
+    assert(v1 == Vector3f(0.0F, 13.0F, 21.0F)) { "v1 has been mutated!" }
+    assert(v2 == Vector3f(-17.0F, -42.0F, 23.0F)) { "v1 has been mutated!" }
+
+    val plusAssign = v1.clone()
+    plusAssign += v2
+    assert(v1 + v2 == plusAssign) { "Vector3f addition&assign has failed!" }
+
+    val minusAssign = v1.clone()
+    minusAssign -= v2
+    assert(v1 - v2 == minusAssign) { "Vector3f subtraction&assign has failed!" }
+
+    val timesAssign = v1.clone()
+    timesAssign *= 23.0F
+    assert(v1 * 23.0F == timesAssign) { "Vector3f multiplication&assign has failed!" }
+
+    KFFLibTest.LOGGER.info("Vector3f test succeed")
+}
+
+internal fun testVector4f() {
+    val v1 = Vector4f(0.0F, 13.0F, 21.0F, -25.0F)
+    val v2 = Vector4f(-17.0F, -42.0F, 23.0F, -13.0F)
+
+    assert(v1 + v2 == Vector4f(-17.0F, -29.0F, 44.0F, -38F)) { "Vector4f addition has failed!" }
+    assert(v1 - v2 == Vector4f(17.0F, 55.0F, -2.0F, -12F)) { "Vector4f subtraction has failed!" }
+    assert(-v1 == Vector4f(0.0F, -13.0F, -21.0F, 25F)) { "Vector4f unaryMinus has failed!" }
+    assert(v1 * 23.0F == Vector4f(0.0F, 299.0F, 483.0F, -575.0F)) { "Vector4f multiplication has failed! " }
+    assert(v1.clone() == v1) { "Vector4f cloning has failed! " }
+
+    assert(v1 == Vector4f(0.0F, 13.0F, 21.0F, -25.0F)) { "v1 has been mutated!" }
+    assert(v2 == Vector4f(-17.0F, -42.0F, 23.0F, -13.0F)) { "v1 has been mutated!" }
+
+    val plusAssign = v1.clone()
+    plusAssign += v2
+    assert(v1 + v2 == plusAssign) { "Vector4f addition&assign has failed!" }
+
+    val minusAssign = v1.clone()
+    minusAssign -= v2
+    assert(v1 - v2 == minusAssign) { "Vector4f subtraction&assign has failed!" }
+
+    val timesAssign = v1.clone()
+    timesAssign *= 23.0F
+    assert(v1 * 23.0F == timesAssign) { "Vector4f multiplication&assign has failed!" }
+
+    KFFLibTest.LOGGER.info("Vector4f test succeed")
+}


### PR DESCRIPTION
I've added syntax sugars and utils for kfflib. For some vector classes, some of them were missing `dot` and `cross` so I also added them.

Changes are:
implemented `+`, `+=`, `-`, `-=`, `*`, `*=`, `-vector` operators for various vector classes
added `clone` for vectors
added `use` for profiler and pose stack. it will handle `push`/`pop`
added `getCapabilityOrThrow` for when an object is guaranteed to have capability