### PR TITLE
Remove deprecated "save state" warnings and use cache

### DIFF
--- a/.github/workflows/kfftest.yml
+++ b/.github/workflows/kfftest.yml
@@ -22,13 +22,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v3
+
     - name: Set up JDK 17
       uses: actions/setup-java@v3
       with:
         java-version: '17'
         distribution: 'temurin'
         
+    - name: Cache Gradle dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/.gradle/caches/
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+          
     - name: Game Test
       uses: gradle/gradle-build-action@v2
       with:

--- a/.github/workflows/kfftest.yml
+++ b/.github/workflows/kfftest.yml
@@ -30,11 +30,11 @@ jobs:
         distribution: 'temurin'
         
     - name: Game Test
-      uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: :kfflib:runGameTestServer
         
     - name: Build test
-      uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+      uses: gradle/gradle-build-action@v2
       with:
         arguments: build

--- a/.github/workflows/test_readme.yml
+++ b/.github/workflows/test_readme.yml
@@ -42,7 +42,7 @@ jobs:
         distribution: 'temurin'
     
     - name: Test README.md
-      uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+      uses: gradle/gradle-build-action@v2
       if: steps.check-readme.outputs.any_changed == 'true'
       with:
         arguments: testREADME


### PR DESCRIPTION
- Use `gradle/gradle-build-action@v2` instead of `gradle/gradle-build-action@hash` to remove the [deprecated warning of save-state](https://github.com/thedarkcolour/KotlinForForge/actions/runs/5383798075)
- Use `action/cache` to improve test speed slightly

*This PR is not that important. Please check it anytime.*