### PR TITLE
4.x conventions plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ runs
 
 # Files from Forge MDK
 forge*changelog.txt
-gradle
 
 # README tester
 .github/readmetester/.gradle

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,72 +1,12 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import thedarkcolour.kotlinforforge.plugin.getPropertyString
-
 plugins {
-    alias(libs.plugins.minotaur)
-    alias(libs.plugins.cursegradle)
-    alias(libs.plugins.neogradle)
     id("kff.common-conventions")
-}
-
-evaluationDependsOnChildren()
-
-subprojects {
-    tasks {
-        withType<KotlinCompile> {
-            compilerOptions.jvmTarget.set(JvmTarget.JVM_21)
-            compilerOptions.freeCompilerArgs.set(listOf("-Xexplicit-api=warning", "-Xjvm-default=all"))
-        }
-    }
-}
-
-val supportedMcVersions = listOf("1.19.3", "1.19.4", "1.20", "1.20.1", "1.20.2")
-
-curseforge {
-    // Use the command line on Linux because IntelliJ doesn't pick up from .bashrc
-    apiKey = System.getenv("CURSEFORGE_API_KEY") ?: "no-publishing-allowed"
-
-    project(closureOf<com.matthewprenger.cursegradle.CurseProject> {
-        id = "351264"
-        releaseType = "release"
-        gameVersionStrings.add("Forge")
-        gameVersionStrings.add("NeoForge")
-        gameVersionStrings.add("Java 17")
-        gameVersionStrings.addAll(supportedMcVersions)
-
-        // from Modrinth's Util.resolveFile
-        @Suppress("DEPRECATION")
-        mainArtifact(project(":combined").tasks.jarJar.get().archivePath, closureOf<com.matthewprenger.cursegradle.CurseArtifact> {
-            displayName = "Kotlin for Forge ${project.version}"
-        })
-    })
-}
-
-modrinth {
-    projectId.set("ordsPcFz")
-    versionName.set("Kotlin for Forge ${project.version}")
-    versionNumber.set("${project.version}")
-    versionType.set("release")
-    gameVersions.addAll(supportedMcVersions)
-    loaders.add("forge")
-    loaders.add("neoforge")
-    uploadFile.provider(project(":combined").tasks.jarJar)
+    alias(libs.plugins.neogradle) apply false
 }
 
 // maven.repo.local is set within the Julia script in the website branch
 tasks.create("publishAllMavens") {
-    for (proj in arrayOf(":forge", ":neoforge")) {
-        finalizedBy(project(proj).tasks.getByName("publishAllMavens"))
-    }
-}
-tasks.create("publishModPlatforms") {
-    finalizedBy(tasks.create("printPublishingMessage") {
-        this.doFirst {
-            println("Publishing Kotlin for Forge ${getPropertyString("kff_version")} to Modrinth and CurseForge")
-        }
-    })
-    finalizedBy(tasks.modrinth)
-    finalizedBy(tasks.curseforge)
+    dependsOn(":forge:publishAllMavens")
+    dependsOn(":neoforge:publishAllMavens")
 }
 
 task<Exec>("testREADME") {
@@ -77,9 +17,4 @@ task<Exec>("testREADME") {
     doLast {
         executionResult.get().assertNormalExitValue()
     }
-}
-
-// Kotlin function ambiguity fix
-fun <T> Property<T>.provider(value: T) {
-    set(value)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,44 +1,21 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import thedarkcolour.kotlinforforge.plugin.getPropertyString
+
 plugins {
-    id("net.neoforged.gradle.userdev") version "[7.0,8.0)"
-    id("com.modrinth.minotaur") version "2.+"
-    id("com.matthewprenger.cursegradle") version "1.4.0"
-}
-
-// Current KFF version
-val kff_version: String by project
-val kffMaxVersion = "${kff_version.split('.')[0].toInt() + 1}.0.0"
-val kffGroup = "thedarkcolour"
-
-allprojects {
-    version = kff_version
-    group = kffGroup
+    alias(libs.plugins.minotaur)
+    alias(libs.plugins.cursegradle)
+    alias(libs.plugins.neogradle)
+    id("kff.common-conventions")
 }
 
 evaluationDependsOnChildren()
 
-val min_mc_version: String by project
-val unsupported_mc_version: String by project
-val min_forge_version: String by project
-val min_neo_version: String by project
-
-val replacements: MutableMap<String, Any> = mutableMapOf(
-    "min_mc_version" to min_mc_version,
-    "unsupported_mc_version" to unsupported_mc_version,
-    "min_forge_version" to min_forge_version,
-    "min_neo_version" to min_neo_version,
-    "kff_version" to kff_version
-)
-val targets = mutableListOf("META-INF/mods.toml")
-
 subprojects {
-    apply(plugin = "java")
     tasks {
-        withType<ProcessResources> {
-            inputs.properties(replacements)
-
-            filesMatching(targets) {
-                expand(replacements)
-            }
+        withType<KotlinCompile> {
+            compilerOptions.jvmTarget.set(JvmTarget.JVM_21)
+            compilerOptions.freeCompilerArgs.set(listOf("-Xexplicit-api=warning", "-Xjvm-default=all"))
         }
     }
 }
@@ -85,7 +62,7 @@ tasks.create("publishAllMavens") {
 tasks.create("publishModPlatforms") {
     finalizedBy(tasks.create("printPublishingMessage") {
         this.doFirst {
-            println("Publishing Kotlin for Forge $kff_version to Modrinth and CurseForge")
+            println("Publishing Kotlin for Forge ${getPropertyString("kff_version")} to Modrinth and CurseForge")
         }
     })
     finalizedBy(tasks.modrinth)

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,6 +13,4 @@ dependencies {
     implementation(gradleApi())
     implementation(kotlin("gradle-plugin"))
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:" + libs.versions.kotlin.get())
-    //implementation("net.neoforged:JarJarSelector:" + libs.versions.jarjar.get())
-    //implementation("net.minecraftforge.gradle:ForgeGradle:" + libs.versions.forgegradle.get())
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,18 @@
+repositories {
+    mavenCentral()
+    gradlePluginPortal()
+    maven("https://maven.neoforged.net/releases")
+    maven("https://maven.minecraftforge.net/")
+}
+
+plugins {
+    `kotlin-dsl`
+}
+
+dependencies {
+    implementation(gradleApi())
+    implementation(kotlin("gradle-plugin"))
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:" + libs.versions.kotlin.get())
+    //implementation("net.neoforged:JarJarSelector:" + libs.versions.jarjar.get())
+    //implementation("net.minecraftforge.gradle:ForgeGradle:" + libs.versions.forgegradle.get())
+}

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/kff.combined-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kff.combined-conventions.gradle.kts
@@ -1,0 +1,34 @@
+import thedarkcolour.kotlinforforge.plugin.getPropertyString
+import java.time.LocalDateTime
+
+project.plugins.apply(JavaPlugin::class)
+
+project.version = getPropertyString("kff_version")
+project.group = "thedarkcolour"
+
+project.tasks.withType<Jar> {
+    // get rid of duplicate files in the ZIP
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
+    val subproject = project.name.substringAfterLast(':')
+
+    from(provider {
+        listOf(
+            zipTree(project(":forge:$subproject").tasks.getByName("jar", Jar::class).archiveFile),
+            zipTree(project(":neoforge:$subproject").tasks.getByName("jar", Jar::class).archiveFile),
+        )
+    })
+
+    manifest {
+        attributes(
+            "Specification-Title" to "Kotlin for Forge",
+            "Specification-Vendor" to "Forge",
+            "Specification-Version" to "1",
+            "Implementation-Title" to project.name,
+            "Implementation-Version" to project.version,
+            "Implementation-Vendor" to "thedarkcolour",
+            "Implementation-Timestamp" to LocalDateTime.now(),
+            "Automatic-Module-Name" to "thedarkcolour.kotlinforforge.$subproject",
+        )
+    }
+}

--- a/buildSrc/src/main/kotlin/kff.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kff.common-conventions.gradle.kts
@@ -1,22 +1,18 @@
-import org.gradle.api.plugins.JavaPlugin
-import org.gradle.api.plugins.JavaPluginExtension
-import org.gradle.jvm.toolchain.JavaLanguageVersion
-import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import thedarkcolour.kotlinforforge.plugin.alias
 import thedarkcolour.kotlinforforge.plugin.getPropertyString
 
-project.plugins.apply(JavaPlugin::class.java)
-project.plugins.apply(IdeaPlugin::class.java)
-project.plugins.apply(MavenPublishPlugin::class.java)
+project.plugins.apply(JavaPlugin::class)
+project.plugins.apply(IdeaPlugin::class)
+project.plugins.apply(MavenPublishPlugin::class)
 project.plugins.apply(alias("kotlinJvm", project))
 
-project.extensions.getByType<JavaPluginExtension>().apply {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
-}
+val jvmTarget = JvmTarget.JVM_17
 
-// I have no idea what I'm doing
+project.extensions.getByType<JavaPluginExtension>().toolchain.languageVersion.set(JavaLanguageVersion.of(jvmTarget.target))
 
-project.version = project.properties["kff_version"] as String
+project.version = getPropertyString("kff_version")
 project.group = "thedarkcolour"
 
 val replacements: MutableMap<String, Any> = mutableMapOf(
@@ -35,5 +31,9 @@ project.tasks {
         filesMatching(targets) {
             expand(replacements)
         }
+    }
+    withType<KotlinCompile> {
+        compilerOptions.jvmTarget.set(jvmTarget)
+        compilerOptions.freeCompilerArgs.set(listOf("-Xexplicit-api=warning", "-Xjvm-default=all"))
     }
 }

--- a/buildSrc/src/main/kotlin/kff.common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kff.common-conventions.gradle.kts
@@ -1,0 +1,39 @@
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.kotlin.dsl.getByType
+import thedarkcolour.kotlinforforge.plugin.alias
+import thedarkcolour.kotlinforforge.plugin.getPropertyString
+
+project.plugins.apply(JavaPlugin::class.java)
+project.plugins.apply(IdeaPlugin::class.java)
+project.plugins.apply(MavenPublishPlugin::class.java)
+project.plugins.apply(alias("kotlinJvm", project))
+
+project.extensions.getByType<JavaPluginExtension>().apply {
+    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+}
+
+// I have no idea what I'm doing
+
+project.version = project.properties["kff_version"] as String
+project.group = "thedarkcolour"
+
+val replacements: MutableMap<String, Any> = mutableMapOf(
+    "min_mc_version" to getPropertyString("min_mc_version"),
+    "unsupported_mc_version" to getPropertyString("unsupported_mc_version"),
+    "min_forge_version" to getPropertyString("min_forge_version"),
+    "min_neo_version" to getPropertyString("min_neo_version"),
+    "kff_version" to getPropertyString("kff_version")
+)
+val targets = mutableListOf("META-INF/mods.toml")
+
+project.tasks {
+    withType<ProcessResources> {
+        inputs.properties(replacements)
+
+        filesMatching(targets) {
+            expand(replacements)
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/kff.forge-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kff.forge-conventions.gradle.kts
@@ -1,0 +1,15 @@
+import thedarkcolour.kotlinforforge.plugin.alias
+import thedarkcolour.kotlinforforge.plugin.getPropertyString
+
+project.plugins.apply("kff.common-conventions")
+project.plugins.apply(alias("forgegradle", project))
+
+project.dependencies {
+    val mcVersion = getPropertyString("mc_version")
+    val fgVersion = getPropertyString("forge_version")
+    minecraft("net.minecraftforge:forge:$mcVersion-$fgVersion")
+}
+
+fun DependencyHandler.minecraft(
+    dependencyNotation: Any
+): Dependency? = add("minecraft", dependencyNotation)

--- a/buildSrc/src/main/kotlin/kff.forge-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kff.forge-conventions.gradle.kts
@@ -10,6 +10,6 @@ project.dependencies {
     minecraft("net.minecraftforge:forge:$mcVersion-$fgVersion")
 }
 
-fun DependencyHandler.minecraft(
-    dependencyNotation: Any
-): Dependency? = add("minecraft", dependencyNotation)
+project.extensions.getByType<JavaPluginExtension>().withSourcesJar()
+
+fun DependencyHandler.minecraft(dependency: String): Dependency? = add("minecraft", dependency)

--- a/buildSrc/src/main/kotlin/kff.neoforge-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kff.neoforge-conventions.gradle.kts
@@ -1,0 +1,4 @@
+import thedarkcolour.kotlinforforge.plugin.alias
+
+project.plugins.apply("kff.common-conventions")
+project.plugins.apply(alias("neogradle", project))

--- a/buildSrc/src/main/kotlin/kff.neoforge-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/kff.neoforge-conventions.gradle.kts
@@ -2,3 +2,5 @@ import thedarkcolour.kotlinforforge.plugin.alias
 
 project.plugins.apply("kff.common-conventions")
 project.plugins.apply(alias("neogradle", project))
+
+project.extensions.getByType<JavaPluginExtension>().withSourcesJar()

--- a/buildSrc/src/main/kotlin/thedarkcolour/kotlinforforge/plugin/Util.kt
+++ b/buildSrc/src/main/kotlin/thedarkcolour/kotlinforforge/plugin/Util.kt
@@ -1,0 +1,19 @@
+package thedarkcolour.kotlinforforge.plugin
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.getByType
+
+fun alias(name: String, project: Project): String {
+    val pluginDep = project.extensions.getByType<VersionCatalogsExtension>().named("libs").findPlugin(name).get().get()
+    return pluginDep.pluginId
+}
+
+fun Project.getKffMaxVersion(): String {
+    val kffVersion = getPropertyString("kff_version")
+    return "${kffVersion.split('.')[0].toInt() + 1}.0.0"
+}
+
+fun Project.getPropertyString(key: String): String {
+    return properties[key] as String
+}

--- a/buildSrc/src/main/kotlin/thedarkcolour/kotlinforforge/plugin/Util.kt
+++ b/buildSrc/src/main/kotlin/thedarkcolour/kotlinforforge/plugin/Util.kt
@@ -10,10 +10,11 @@ fun alias(name: String, project: Project): String {
 }
 
 fun Project.getKffMaxVersion(): String {
-    val kffVersion = getPropertyString("kff_version")
+    val kffVersion = project.version.toString()
+    assert(kffVersion != "unspecified")
     return "${kffVersion.split('.')[0].toInt() + 1}.0.0"
 }
 
 fun Project.getPropertyString(key: String): String {
-    return properties[key] as String
+    return rootProject.properties[key] as String
 }

--- a/combined/build.gradle.kts
+++ b/combined/build.gradle.kts
@@ -1,8 +1,8 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm")
-    id("net.neoforged.gradle.userdev") version "[7.0,8.0)"
+    id("kff.common-conventions")
+    alias(libs.plugins.neogradle)
     `maven-publish`
 }
 
@@ -19,10 +19,6 @@ val shadow: Configuration by configurations.creating {
 
 base {
     archivesName.set("kotlinforforge")
-}
-
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
 }
 
 configurations {
@@ -43,29 +39,26 @@ repositories {
 jarJar.enable()
 
 dependencies {
-    shadow("org.jetbrains.kotlin:kotlin-reflect:${kotlin.coreLibrariesVersion}")
-    shadow("org.jetbrains.kotlin:kotlin-stdlib:${kotlin.coreLibrariesVersion}")
-    shadow("org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin.coreLibrariesVersion}")
-    shadow("org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutines_version}")
-    shadow("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:${coroutines_version}")
-    shadow("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:${coroutines_version}")
-    shadow("org.jetbrains.kotlinx:kotlinx-serialization-core:${serialization_version}")
-    shadow("org.jetbrains.kotlinx:kotlinx-serialization-json:${serialization_version}")
+    shadow(libs.kotlin.reflect)
+    shadow(libs.kotlin.stdlib)
+    shadow(libs.kotlinx.coroutines.core)
+    shadow(libs.kotlinx.coroutines.core.jvm)
+    shadow(libs.kotlinx.coroutines.jdk8)
+    shadow(libs.kotlinx.serialization.core)
+    shadow(libs.kotlinx.serialization.json)
 
     // KFF Modules
-    implementation(include(project(":combined:kfflang"), kffMaxVersion))
-    implementation(include(project(":combined:kfflib"), kffMaxVersion))
-    implementation(include(project(":combined:kffmod"), kffMaxVersion))
+    implementation(include(projects.combined.kfflang))
+    implementation(include(projects.combined.kfflib))
+    implementation(include(projects.combined.kffmod))
 }
 
-fun DependencyHandler.include(dep: ModuleDependency, maxVersion: String? = null): ModuleDependency {
+fun DependencyHandler.include(dep: ModuleDependency): ModuleDependency {
     api(dep) // Add module metadata compileOnly dependency
     jarJar(dep.copy()) {
         isTransitive = false
         jarJar.pin(this, version)
-        if (maxVersion != null) {
-            jarJar.ranged(this, "[$version,$maxVersion)")
-        }
+        jarJar.ranged(this, "[$version,$kffMaxVersion)")
     }
     return dep
 }

--- a/combined/build.gradle.kts
+++ b/combined/build.gradle.kts
@@ -1,25 +1,16 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import thedarkcolour.kotlinforforge.plugin.getKffMaxVersion
+import thedarkcolour.kotlinforforge.plugin.getPropertyString
 
 plugins {
     id("kff.common-conventions")
     alias(libs.plugins.neogradle)
-    `maven-publish`
+    alias(libs.plugins.minotaur)
+    alias(libs.plugins.cursegradle)
 }
 
-val kff_version: String by project
-val kffMaxVersion = "${kff_version.split(".")[0].toInt() + 1}.0.0"
-val kffGroup = "thedarkcolour"
+base.archivesName.set("kotlinforforge")
 
-val coroutines_version: String by project
-val serialization_version: String by project
-
-val shadow: Configuration by configurations.creating {
-    exclude("org.jetbrains", "annotations")
-}
-
-base {
-    archivesName.set("kotlinforforge")
-}
+evaluationDependsOnChildren()
 
 configurations {
     apiElements {
@@ -38,6 +29,10 @@ repositories {
 
 jarJar.enable()
 
+val shadow: Configuration by configurations.creating {
+    exclude("org.jetbrains", "annotations")
+}
+
 dependencies {
     shadow(libs.kotlin.reflect)
     shadow(libs.kotlin.stdlib)
@@ -48,26 +43,24 @@ dependencies {
     shadow(libs.kotlinx.serialization.json)
 
     // KFF Modules
-    implementation(include(projects.combined.kfflang))
-    implementation(include(projects.combined.kfflib))
-    implementation(include(projects.combined.kffmod))
+    include(projects.combined.kfflang)
+    include(projects.combined.kfflib)
+    include(projects.combined.kffmod)
 }
 
-fun DependencyHandler.include(dep: ModuleDependency): ModuleDependency {
-    api(dep) // Add module metadata compileOnly dependency
+fun DependencyHandler.include(dep: ModuleDependency) {
+    val version = project.version.toString()
+    val kffMaxVersion = getKffMaxVersion()
+    api(dep)
+
     jarJar(dep.copy()) {
         isTransitive = false
         jarJar.pin(this, version)
         jarJar.ranged(this, "[$version,$kffMaxVersion)")
     }
-    return dep
 }
 
 tasks {
-    jar {
-        enabled = false
-    }
-
     jarJar.configure {
         from(provider { shadow.map(::zipTree).toTypedArray() })
         manifest {
@@ -78,27 +71,59 @@ tasks {
         }
     }
 
-    whenTaskAdded {
-        // Disable reobfJar
-        if (name == "reobfJar") {
-            enabled = false
-        }
-        // Fight ForgeGradle and Forge crashing when MOD_CLASSES don't exist
-        if (name == "prepareRuns") {
-            doFirst {
-                sourceSets.main.get().output.files.forEach(File::mkdirs)
-            }
-        }
-    }
-
-    withType<KotlinCompile> {
-        kotlinOptions.jvmTarget = "17"
-    }
-
     assemble {
         dependsOn(":combined:kfflang:build")
         dependsOn(":combined:kfflib:build")
         dependsOn(":combined:kffmod:build")
         dependsOn(jarJar)
     }
+}
+
+
+val supportedMcVersions = listOf("1.19.3", "1.19.4", "1.20", "1.20.1", "1.20.2")
+
+curseforge {
+    // Use the command line on Linux because IntelliJ doesn't pick up from .bashrc
+    apiKey = System.getenv("CURSEFORGE_API_KEY") ?: "no-publishing-allowed"
+
+    project(closureOf<com.matthewprenger.cursegradle.CurseProject> {
+        id = "351264"
+        releaseType = "release"
+        gameVersionStrings.add("Forge")
+        gameVersionStrings.add("NeoForge")
+        gameVersionStrings.add("Java 17")
+        gameVersionStrings.addAll(supportedMcVersions)
+
+        // from Modrinth's Util.resolveFile
+        mainArtifact(
+            project(":combined").tasks.jarJar.get().archiveFile,
+            closureOf<com.matthewprenger.cursegradle.CurseArtifact> {
+                displayName = "Kotlin for Forge ${project.version}"
+            })
+    })
+}
+
+modrinth {
+    projectId.set("ordsPcFz")
+    versionName.set("Kotlin for Forge ${project.version}")
+    versionNumber.set("${project.version}")
+    versionType.set("release")
+    gameVersions.addAll(supportedMcVersions)
+    loaders.add("forge")
+    loaders.add("neoforge")
+    uploadFile.provider(project(":combined").tasks.jarJar)
+}
+tasks.create("publishModPlatforms") {
+    finalizedBy(tasks.create("printPublishingMessage") {
+        doFirst {
+            println("Publishing Kotlin for Forge ${getPropertyString("kff_version")} to Modrinth and CurseForge")
+        }
+    })
+    finalizedBy(tasks.modrinth)
+    finalizedBy(tasks.curseforge)
+}
+
+// Kotlin function ambiguity fix
+fun <T> Property<T>.provider(value: T) {
+    set(value)
 }

--- a/combined/kfflang/build.gradle.kts
+++ b/combined/kfflang/build.gradle.kts
@@ -1,34 +1,10 @@
-import java.time.LocalDateTime
-
 plugins {
-    java
+    id("kff.combined-conventions")
 }
-
-val kff_version: String by project
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(17))
 
 tasks {
     jar {
-        duplicatesStrategy = DuplicatesStrategy.INCLUDE
-
-        from(provider {
-            listOf(
-                zipTree((project(":forge:kfflang").tasks.getByName("jar") as Jar).archiveFile),
-                zipTree((project(":neoforge:kfflang").tasks.getByName("jar") as Jar).archiveFile),
-            )
-        })
-
-        manifest {
-            attributes(
-                "Specification-Title" to "Kotlin for Forge",
-                "Specification-Vendor" to "Forge",
-                "Specification-Version" to "1",
-                "Implementation-Title" to project.name,
-                "Implementation-Version" to project.version,
-                "Implementation-Vendor" to "thedarkcolour",
-                "Implementation-Timestamp" to LocalDateTime.now(),
-                "Automatic-Module-Name" to "thedarkcolour.kotlinforforge.lang",
-                "FMLModType" to "LANGPROVIDER",
-            )
-        }
+        manifest.attributes["FMLModType"] = "LANGPROVIDER"
     }
 }

--- a/combined/kfflib/build.gradle.kts
+++ b/combined/kfflib/build.gradle.kts
@@ -1,34 +1,11 @@
-import java.time.LocalDateTime
-
 plugins {
-    java
+    id("kff.combined-conventions")
 }
 
-val kff_version: String by project
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(17))
 
 tasks {
     jar {
-        duplicatesStrategy = DuplicatesStrategy.INCLUDE
-
-        from(provider {
-            listOf(
-                zipTree((project(":forge:kfflib").tasks.getByName("jar") as Jar).archiveFile),
-                zipTree((project(":neoforge:kfflib").tasks.getByName("jar") as Jar).archiveFile),
-            )
-        })
-
-        manifest {
-            attributes(
-                "Specification-Title" to "Kotlin for Forge",
-                "Specification-Vendor" to "Forge",
-                "Specification-Version" to "1",
-                "Implementation-Title" to project.name,
-                "Implementation-Version" to project.version,
-                "Implementation-Vendor" to "thedarkcolour",
-                "Implementation-Timestamp" to LocalDateTime.now(),
-                "Automatic-Module-Name" to "thedarkcolour.kotlinforforge.lib",
-                "FMLModType" to "GAMELIBRARY",
-            )
-        }
+        manifest.attributes["FMLModType"] = "GAMELIBRARY"
     }
 }

--- a/combined/kffmod/build.gradle.kts
+++ b/combined/kffmod/build.gradle.kts
@@ -1,33 +1,4 @@
-import java.time.LocalDateTime
-
 plugins {
-    java
+    id("kff.combined-conventions")
 }
-
-val kff_version: String by project
-
-tasks {
-    jar {
-        duplicatesStrategy = DuplicatesStrategy.INCLUDE
-
-        from(provider {
-            listOf(
-                zipTree((project(":forge:kffmod").tasks.getByName("jar") as Jar).archiveFile),
-                zipTree((project(":neoforge:kffmod").tasks.getByName("jar") as Jar).archiveFile),
-            )
-        })
-
-        manifest {
-            attributes(
-                "Specification-Title" to "Kotlin for Forge",
-                "Specification-Vendor" to "Forge",
-                "Specification-Version" to "1",
-                "Implementation-Title" to project.name,
-                "Implementation-Version" to project.version,
-                "Implementation-Vendor" to "thedarkcolour",
-                "Implementation-Timestamp" to LocalDateTime.now(),
-                "Automatic-Module-Name" to "thedarkcolour.kotlinforforge.mod",
-            )
-        }
-    }
-}
+java.toolchain.languageVersion.set(JavaLanguageVersion.of(17))

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -1,40 +1,24 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import thedarkcolour.kotlinforforge.plugin.getKffMaxVersion
 
 plugins {
-    kotlin("jvm")
-    id("net.minecraftforge.gradle") version "[6.0,6.2)"
-    id("com.modrinth.minotaur") version "2.+"
+    alias(libs.plugins.forgegradle)
+    id("kff.forge-conventions")
     `maven-publish`
-    id("com.matthewprenger.cursegradle") version "1.4.0"
 }
 
-// Current KFF version
-val kff_version: String by project
-val kffMaxVersion = "${kff_version.split('.')[0].toInt() + 1}.0.0"
-val kffGroup = "thedarkcolour"
-
-allprojects {
-    version = kff_version
-    group = kffGroup
-}
+val kffMaxVersion = getKffMaxVersion()
 
 evaluationDependsOnChildren()
 
 val mc_version: String by project
 val forge_version: String by project
 
-val coroutines_version: String by project
-val serialization_version: String by project
-
 val shadow: Configuration by configurations.creating {
     exclude("org.jetbrains", "annotations")
 }
 
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
-    withSourcesJar()
-}
-
+java.withSourcesJar()
 jarJar.enable()
 
 configurations {
@@ -77,16 +61,13 @@ repositories {
 }
 
 dependencies {
-    minecraft("net.minecraftforge:forge:$mc_version-$forge_version")
-
-    shadow("org.jetbrains.kotlin:kotlin-reflect:${kotlin.coreLibrariesVersion}")
-    shadow("org.jetbrains.kotlin:kotlin-stdlib:${kotlin.coreLibrariesVersion}")
-    shadow("org.jetbrains.kotlin:kotlin-stdlib-common:${kotlin.coreLibrariesVersion}")
-    shadow("org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutines_version}")
-    shadow("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:${coroutines_version}")
-    shadow("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:${coroutines_version}")
-    shadow("org.jetbrains.kotlinx:kotlinx-serialization-core:${serialization_version}")
-    shadow("org.jetbrains.kotlinx:kotlinx-serialization-json:${serialization_version}")
+    shadow(libs.kotlin.reflect)
+    shadow(libs.kotlin.stdlib)
+    shadow(libs.kotlinx.coroutines.core)
+    shadow(libs.kotlinx.coroutines.core.jvm)
+    shadow(libs.kotlinx.coroutines.jdk8)
+    shadow(libs.kotlinx.serialization.core)
+    shadow(libs.kotlinx.serialization.json)
 
     // KFF Modules
     implementation(include(project(":forge:kfflang"), kffMaxVersion))
@@ -140,10 +121,6 @@ publishing {
         }
     }
 }
-
-fun DependencyHandler.minecraft(
-    dependencyNotation: Any
-): Dependency? = add("minecraft", dependencyNotation)
 
 // maven.repo.local is set within the Julia script in the website branch
 tasks.create("publishAllMavens") {

--- a/forge/kfflang/build.gradle.kts
+++ b/forge/kfflang/build.gradle.kts
@@ -1,18 +1,11 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.time.LocalDateTime
 
 plugins {
     id("kff.forge-conventions")
-    `maven-publish`
 }
 
 val mc_version: String by project
 val forge_version: String by project
-
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
-    withSourcesJar()
-}
 
 minecraft {
     mappings("official", mc_version)
@@ -95,11 +88,6 @@ tasks {
                 "FMLModType" to "LANGPROVIDER",
             )
         }
-    }
-
-    // Only require the lang provider to use explicit visibility modifiers, not the test mod
-    withType<KotlinCompile> {
-        kotlinOptions.freeCompilerArgs = listOf("-Xexplicit-api=warning", "-Xjvm-default=all")
     }
 }
 

--- a/forge/kfflang/build.gradle.kts
+++ b/forge/kfflang/build.gradle.kts
@@ -2,11 +2,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.time.LocalDateTime
 
 plugins {
-    kotlin("jvm")
-    id("net.minecraftforge.gradle")
+    id("kff.forge-conventions")
     `maven-publish`
-    eclipse
-    idea
 }
 
 val mc_version: String by project

--- a/forge/kfflib/build.gradle.kts
+++ b/forge/kfflib/build.gradle.kts
@@ -3,16 +3,9 @@ import java.time.LocalDateTime
 
 plugins {
     id("kff.forge-conventions")
-    `maven-publish`
 }
 
 val mc_version: String by project
-val forge_version: String by project
-
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
-    withSourcesJar()
-}
 
 minecraft {
     mappings("official", mc_version)
@@ -125,7 +118,7 @@ tasks {
             )
         }
     }
-    
+
     // Only require the lang provider to use explicit visibility modifiers, not the test mod
     withType<KotlinCompile> {
         kotlinOptions.freeCompilerArgs = listOf("-Xexplicit-api=warning", "-Xjvm-default=all")

--- a/forge/kfflib/build.gradle.kts
+++ b/forge/kfflib/build.gradle.kts
@@ -2,18 +2,12 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.time.LocalDateTime
 
 plugins {
-    kotlin("jvm")
-    kotlin("plugin.serialization")
-    id("net.minecraftforge.gradle")
+    id("kff.forge-conventions")
     `maven-publish`
-    eclipse
-    idea
 }
 
 val mc_version: String by project
 val forge_version: String by project
-val coroutines_version: String by project
-val serialization_version: String by project
 
 java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(17))
@@ -104,16 +98,15 @@ configurations {
 }
 
 dependencies {
-    minecraft("net.minecraftforge:forge:$mc_version-$forge_version")
+    // Default classpath
+    api(libs.kotlin.stdlib.jdk8)
+    api(libs.kotlin.reflect)
+    api(libs.kotlinx.coroutines.core)
+    api(libs.kotlinx.coroutines.core.jvm)
+    api(libs.kotlinx.coroutines.jdk8)
+    api(libs.kotlinx.serialization.json)
 
-    api(kotlin("stdlib-jdk8"))
-    api(kotlin("reflect"))
-    api("org.jetbrains.kotlinx", "kotlinx-coroutines-core", coroutines_version)
-    api("org.jetbrains.kotlinx", "kotlinx-coroutines-core-jvm", coroutines_version)
-    api("org.jetbrains.kotlinx", "kotlinx-coroutines-jdk8", coroutines_version)
-    api("org.jetbrains.kotlinx", "kotlinx-serialization-json", serialization_version)
-
-    implementation(project(":forge:kfflang"))
+    implementation(projects.forge.kfflang)
 }
 
 tasks {

--- a/forge/kffmod/build.gradle.kts
+++ b/forge/kffmod/build.gradle.kts
@@ -1,22 +1,11 @@
-import java.time.LocalDateTime
+import thedarkcolour.kotlinforforge.plugin.getPropertyString
 
 plugins {
     id("kff.forge-conventions")
-    `maven-publish`
-    idea
-}
-
-val mc_version: String by project
-val forge_version: String by project
-val kotlin_version: String by project
-
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
-    withSourcesJar()
 }
 
 minecraft {
-    mappings("official", mc_version)
+    mappings("official", getPropertyString("mc_version"))
     copyIdeResources.set(true)
 
     runs {

--- a/forge/kffmod/build.gradle.kts
+++ b/forge/kffmod/build.gradle.kts
@@ -1,10 +1,8 @@
 import java.time.LocalDateTime
 
 plugins {
-    kotlin("jvm")
-    id("net.minecraftforge.gradle")
+    id("kff.forge-conventions")
     `maven-publish`
-    eclipse
     idea
 }
 
@@ -57,8 +55,6 @@ repositories {
 }
 
 dependencies {
-    minecraft("net.minecraftforge:forge:$mc_version-$forge_version")
-
     // Default classpath
     api(kotlin("stdlib"))
     api(kotlin("stdlib-common"))
@@ -68,22 +64,6 @@ dependencies {
 
     implementation(project(":forge:kfflang"))
     implementation(project(":forge:kfflib"))
-}
-
-tasks {
-    withType<Jar> {
-        manifest {
-            attributes(
-                "Specification-Title" to "Kotlin for Forge",
-                "Specification-Vendor" to "Forge",
-                "Specification-Version" to "1",
-                "Implementation-Title" to project.name,
-                "Implementation-Version" to project.version,
-                "Implementation-Vendor" to "thedarkcolour",
-                "Implementation-Timestamp" to LocalDateTime.now()
-            )
-        }
-    }
 }
 
 publishing {

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,11 +15,4 @@ forge_version=49.0.8
 min_neo_version = 20.2.3-beta
 neo_version = 20.4.22-beta
 
-kff_version=4.10.0
-
-# https://github.com/JetBrains/kotlin
-kotlin_version=1.9.22
-# https://github.com/Kotlin/kotlinx.coroutines
-coroutines_version=1.7.3
-# https://github.com/Kotlin/kotlinx.serialization
-serialization_version = 1.6.2
+kff_version=4.11.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,33 @@
+[versions]
+kotlin = "2.0.0"
+coroutines = "1.8.1"
+serialization = "1.6.3"
+neogradle = "7.0.137"
+neoforge = "20.4.22-beta"
+forgegradle = "6.0.25"
+minotaur = "2.8.7"
+cursegradle = "1.4.0"
+jarjar = "0.4.1"
+
+# https://github.com/JetBrains/kotlin
+# https://github.com/Kotlin/kotlinx.coroutines
+# https://github.com/Kotlin/kotlinx.serialization
+[libraries]
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+kotlin-stdlib-jdk7 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk7", version.ref = "kotlin" }
+kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-coroutines-core-jvm = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm", version.ref = "coroutines" }
+kotlinx-coroutines-jdk8 = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8", version.ref = "coroutines" }
+kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "serialization" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "serialization" }
+neoforge = { module = "net.neoforged:neoforge", version.ref = "neoforge" }
+
+[plugins]
+kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+neogradle = { id = "net.neoforged.gradle.userdev", version.ref = "neogradle" }
+jarjar = { id = "net.neoforged.jarjar", version.ref = "jarjar" }
+forgegradle = { id = "net.minecraftforge.gradle", version.ref = "forgegradle" }
+minotaur = { id = "com.modrinth.minotaur", version.ref = "minotaur" }
+cursegradle = { id = "com.matthewprenger.cursegradle", version.ref = "cursegradle" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,12 +2,11 @@
 kotlin = "2.0.0"
 coroutines = "1.8.1"
 serialization = "1.6.3"
-neogradle = "7.0.137"
+neogradle = "7.0.138"
 neoforge = "20.4.22-beta"
 forgegradle = "6.0.25"
 minotaur = "2.8.7"
 cursegradle = "1.4.0"
-jarjar = "0.4.1"
 
 # https://github.com/JetBrains/kotlin
 # https://github.com/Kotlin/kotlinx.coroutines
@@ -27,7 +26,6 @@ neoforge = { module = "net.neoforged:neoforge", version.ref = "neoforge" }
 [plugins]
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 neogradle = { id = "net.neoforged.gradle.userdev", version.ref = "neogradle" }
-jarjar = { id = "net.neoforged.jarjar", version.ref = "jarjar" }
 forgegradle = { id = "net.minecraftforge.gradle", version.ref = "forgegradle" }
 minotaur = { id = "com.modrinth.minotaur", version.ref = "minotaur" }
 cursegradle = { id = "com.matthewprenger.cursegradle", version.ref = "cursegradle" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/neoforge/kfflang/build.gradle.kts
+++ b/neoforge/kfflang/build.gradle.kts
@@ -1,21 +1,15 @@
 import net.neoforged.gradle.dsl.common.extensions.RunnableSourceSet
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.jetbrains.kotlin.gradle.utils.extendsFrom
 import java.time.LocalDateTime
 
 plugins {
     id("kff.neoforge-conventions")
 }
 
-java {
-    withSourcesJar()
-}
-
 // Tells NeoGradle to treat this source set as a separate mod
-sourceSets["test"].extensions.getByType<RunnableSourceSet>().configure { runnable -> runnable.modIdentifier("kfflangtest") }
+sourceSets["test"].extensions.getByType<RunnableSourceSet>().configure { run -> run.modIdentifier("kfflangtest") }
 
-val nonmclibs: Configuration by configurations.creating {
-}
+val nonmclibs: Configuration by configurations.creating {}
 
 runs {
     configureEach {

--- a/neoforge/kfflang/build.gradle.kts
+++ b/neoforge/kfflang/build.gradle.kts
@@ -4,17 +4,10 @@ import org.jetbrains.kotlin.gradle.utils.extendsFrom
 import java.time.LocalDateTime
 
 plugins {
-    kotlin("jvm")
-    id("net.neoforged.gradle.userdev")
-    `maven-publish`
-    eclipse
-    idea
+    id("kff.neoforge-conventions")
 }
 
-val neo_version: String by project
-
 java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
     withSourcesJar()
 }
 
@@ -27,7 +20,7 @@ val nonmclibs: Configuration by configurations.creating {
 runs {
     configureEach {
         modSource(sourceSets["main"])
-        modSource(sourceSets["test"])
+        //modSource(sourceSets["test"])
         dependencies {
             runtime((nonmclibs))
         }
@@ -39,7 +32,7 @@ runs {
 }
 
 dependencies {
-    implementation("net.neoforged:neoforge:${project.properties["neo_version"]}")
+    implementation(libs.neoforge)
 
     configurations.getByName("api").extendsFrom(nonmclibs)
 

--- a/neoforge/kfflib/build.gradle.kts
+++ b/neoforge/kfflib/build.gradle.kts
@@ -22,14 +22,14 @@ dependencies {
     implementation("net.neoforged:neoforge:${project.properties["neo_version"]}")
 
     // Default classpath
-    api(kotlin("stdlib-jdk8"))
-    api(kotlin("reflect"))
-    api("org.jetbrains.kotlinx", "kotlinx-coroutines-core", coroutines_version)
-    api("org.jetbrains.kotlinx", "kotlinx-coroutines-core-jvm", coroutines_version)
-    api("org.jetbrains.kotlinx", "kotlinx-coroutines-jdk8", coroutines_version)
-    api("org.jetbrains.kotlinx", "kotlinx-serialization-json", serialization_version)
+    api(libs.kotlin.stdlib.jdk8)
+    api(libs.kotlin.reflect)
+    api(libs.kotlinx.coroutines.core)
+    api(libs.kotlinx.coroutines.core.jvm)
+    api(libs.kotlinx.coroutines.jdk8)
+    api(libs.kotlinx.serialization.json)
 
-    implementation(project(":neoforge:kfflang"))
+    implementation(projects.neoforge.kfflang)
 }
 
 tasks {

--- a/neoforge/kfflib/build.gradle.kts
+++ b/neoforge/kfflib/build.gradle.kts
@@ -1,21 +1,7 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.time.LocalDateTime
 
 plugins {
-    kotlin("jvm")
-    id("net.neoforged.gradle.userdev")
-    `maven-publish`
-    eclipse
-    idea
-}
-
-val neo_version: String by project
-val coroutines_version: String by project
-val serialization_version: String by project
-
-java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
-    withSourcesJar()
+    id("kff.neoforge-conventions")
 }
 
 dependencies {
@@ -47,11 +33,6 @@ tasks {
                 "FMLModType" to "GAMELIBRARY",
             )
         }
-    }
-
-    // Only require the lang provider to use explicit visibility modifiers, not the test mod
-    withType<KotlinCompile> {
-        kotlinOptions.freeCompilerArgs = listOf("-Xexplicit-api=warning", "-Xjvm-default=all")
     }
 }
 

--- a/neoforge/kffmod/build.gradle.kts
+++ b/neoforge/kffmod/build.gradle.kts
@@ -1,12 +1,5 @@
-import java.time.LocalDateTime
-
 plugins {
     id("kff.neoforge-conventions")
-    `maven-publish`
-}
-
-java {
-    withSourcesJar()
 }
 
 runs {

--- a/neoforge/kffmod/build.gradle.kts
+++ b/neoforge/kffmod/build.gradle.kts
@@ -1,20 +1,11 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.time.LocalDateTime
 
 plugins {
-    kotlin("jvm")
-    id("net.neoforged.gradle.userdev")
+    id("kff.neoforge-conventions")
     `maven-publish`
-    eclipse
-    idea
 }
 
-val neo_version: String by project
-val coroutines_version: String by project
-val serialization_version: String by project
-
 java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
     withSourcesJar()
 }
 
@@ -27,43 +18,21 @@ runs {
 }
 
 dependencies {
-    implementation("net.neoforged:neoforge:${project.properties["neo_version"]}")
+    implementation(libs.neoforge)
 
     // Default classpath
-    api(kotlin("stdlib-jdk8"))
-    api(kotlin("reflect"))
-    api("org.jetbrains.kotlinx", "kotlinx-coroutines-core", coroutines_version)
-    api("org.jetbrains.kotlinx", "kotlinx-coroutines-core-jvm", coroutines_version)
-    api("org.jetbrains.kotlinx", "kotlinx-coroutines-jdk8", coroutines_version)
-    api("org.jetbrains.kotlinx", "kotlinx-serialization-json", serialization_version)
+    api(libs.kotlin.stdlib.jdk8)
+    api(libs.kotlin.reflect)
+    api(libs.kotlinx.coroutines.core)
+    api(libs.kotlinx.coroutines.core.jvm)
+    api(libs.kotlinx.coroutines.jdk8)
+    api(libs.kotlinx.serialization.json)
 
-    implementation(project(":neoforge:kfflang")) {
+    implementation(projects.neoforge.kfflang) {
         isTransitive = false
     }
-    implementation(project(":neoforge:kfflib")) {
+    implementation(projects.neoforge.kfflib) {
         isTransitive = false
-    }
-}
-
-tasks {
-    withType<Jar> {
-        manifest {
-            attributes(
-                "Specification-Title" to "Kotlin for Forge",
-                "Specification-Vendor" to "Forge",
-                "Specification-Version" to "1",
-                "Implementation-Title" to project.name,
-                "Implementation-Version" to project.version,
-                "Implementation-Vendor" to "thedarkcolour",
-                "Implementation-Timestamp" to LocalDateTime.now(),
-                "Automatic-Module-Name" to "thedarkcolour.kotlinforforge.lang"
-            )
-        }
-    }
-
-    // Only require the lang provider to use explicit visibility modifiers, not the test mod
-    withType<KotlinCompile> {
-        kotlinOptions.freeCompilerArgs = listOf("-Xexplicit-api=warning", "-Xjvm-default=all")
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,10 +4,7 @@ pluginManagement {
         maven("https://maven.minecraftforge.net/")
         maven("https://maven.neoforged.net/releases")
     }
-    val kotlin_version: String by settings
     plugins {
-        kotlin("jvm") version kotlin_version
-        kotlin("plugin.serialization") version kotlin_version
         id ("org.gradle.toolchains.foojay-resolver-convention") version ("0.5.0")
     }
 }
@@ -16,4 +13,6 @@ include("forge:kfflang",    "forge:kfflib",    "forge:kffmod"   )
 include("neoforge:kfflang", "neoforge:kfflib", "neoforge:kffmod")
 include("combined:kfflang", "combined:kfflib", "combined:kffmod")
 
-//rootProject.name = "kotlinforforge"
+rootProject.name = "KotlinForForge"
+
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")


### PR DESCRIPTION
Share common build logic using conventions plugins. Remove uses of `allprojects` and `subprojects`. Use versions catalogue for keeping track of dependencies.