### PR TITLE
Improve PoseStack.use extension method

### DIFF
--- a/forge/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/forge/PoseStackUtil.kt
+++ b/forge/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/forge/PoseStackUtil.kt
@@ -3,10 +3,13 @@ package thedarkcolour.kotlinforforge.forge
 import com.mojang.blaze3d.vertex.PoseStack
 import org.joml.Quaternionf
 
-public fun PoseStack.use(toRun: () -> Unit) {
+public inline fun <R> PoseStack.use(toRun: (PoseStack) -> R): R {
     pushPose()
-    toRun()
+    val result = toRun(this)
     popPose()
+    return result
 }
+
+public inline fun <R> PoseStack.use(toRun: () -> R): R = use { _ -> toRun() }
 
 public operator fun PoseStack.timesAssign(matrix: Quaternionf): Unit = mulPose(matrix)

--- a/neoforge/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/neoforge/forge/PoseStackUtil.kt
+++ b/neoforge/kfflib/src/main/kotlin/thedarkcolour/kotlinforforge/neoforge/forge/PoseStackUtil.kt
@@ -3,10 +3,13 @@ package thedarkcolour.kotlinforforge.neoforge.forge
 import com.mojang.blaze3d.vertex.PoseStack
 import org.joml.Quaternionf
 
-public fun PoseStack.use(toRun: () -> Unit) {
+public inline fun <R> PoseStack.use(toRun: (PoseStack) -> R): R {
     pushPose()
-    toRun()
+    val result = toRun(this)
     popPose()
+    return result
 }
+
+public inline fun <R> PoseStack.use(toRun: () -> R): R = use { _ -> toRun() }
 
 public operator fun PoseStack.timesAssign(matrix: Quaternionf): Unit = mulPose(matrix)


### PR DESCRIPTION
1. Make the method inline so that `return` statements can be used inside the lambda passed in.

2. Let the lambda argument accept a `PoseStack` object as what `use` extension method within the Kotlin standard library does. Also provide a non-`PoseStack`-object version overload of the method that invokes the original `PoseStack.use` method ahead.