### PR TITLE
Fixed typo in usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,5 +101,5 @@ modLoader="kotlinforforge"
 loaderVersion="[6.0,)"
 ```
 
-Use `thedarkcolour.kotlinforforge.forge.MOD_BUS` instead of        
+Use `thedarkcolour.kotlinforforge.forge.MOD_BUS`     
 instead of `net.minecraftforge.fml.javafmlmod.FMLJavaModLoadingContext`


### PR DESCRIPTION
Fixed typo introduced in [6c7ec39d6cdf037edc80fce6555232b5494c9afe](https://github.com/thedarkcolour/KotlinForForge/commit/6c7ec39d6cdf037edc80fce6555232b5494c9afe)