### PR TITLE
[4.x] Bump Kotlin libraries.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 ## Kotlin for Forge 4.13.0
-- Update to Kotlin 2.3.21, serialization 1.11.0, coroutines 1.11.0
+- Update to Kotlin 2.4.0, serialization 1.11.0, coroutines 1.11.0
 
 ## Kotlin for Forge 4.12.0
 - Update to Kotlin 2.2.21, serialization 1.9.0, coroutines 1.10.2

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+## Kotlin for Forge 4.13.0
+- Update to Kotlin 2.3.21, serialization 1.11.0, coroutines 1.10.2
+
 ## Kotlin for Forge 4.12.0
 - Update to Kotlin 2.2.21, serialization 1.9.0, coroutines 1.10.2
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 ## Kotlin for Forge 4.13.0
-- Update to Kotlin 2.3.21, serialization 1.11.0, coroutines 1.10.2
+- Update to Kotlin 2.3.21, serialization 1.11.0, coroutines 1.11.0
 
 ## Kotlin for Forge 4.12.0
 - Update to Kotlin 2.2.21, serialization 1.9.0, coroutines 1.10.2

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 ## Kotlin for Forge 4.13.0
-- Update to Kotlin 2.4.0, serialization 1.11.0, coroutines 1.11.0
+- Update to Kotlin 2.4.10, serialization 1.11.0, coroutines 1.11.0
 
 ## Kotlin for Forge 4.12.0
 - Update to Kotlin 2.2.21, serialization 1.9.0, coroutines 1.10.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ forge_version=49.0.8
 min_neo_version = 20.2.3-beta
 neo_version = 20.4.22-beta
 
-kff_version=4.12.0
+kff_version=4.13.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.4.0"
+kotlin = "2.4.10"
 coroutines = "1.11.0"
 serialization = "1.11.0"
 neogradle = "7.0.138"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
-kotlin = "2.2.21"
+kotlin = "2.3.21"
 coroutines = "1.10.2"
-serialization = "1.9.0"
+serialization = "1.11.0"
 neogradle = "7.0.138"
 neoforge = "20.4.22-beta"
 forgegradle = "6.0.25"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlin = "2.3.21"
-coroutines = "1.10.2"
+coroutines = "1.11.0"
 serialization = "1.11.0"
 neogradle = "7.0.138"
 neoforge = "20.4.22-beta"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.3.21"
+kotlin = "2.4.0"
 coroutines = "1.11.0"
 serialization = "1.11.0"
 neogradle = "7.0.138"


### PR DESCRIPTION
Simple PR to bump the Kotlin libraries on the 1.19.3 - 1.20.4 version (4.x)

Kotlin: 2.2.21 to 2.4.0
Coroutines: 1.10.2 to 1.11.0
Serialization: 1.9.0 to 1.11.0

I also bumped the KFF version to 4.13.0 and added the changelog entry describing the version bumps.

_* Tested on 1.20.1 using the DeceasedCraft modpack, with no noticeable issues_